### PR TITLE
Timezone debug

### DIFF
--- a/src/util-time.c
+++ b/src/util-time.c
@@ -203,12 +203,19 @@ static inline void WinStrftime(const struct timeval *ts, const struct tm *t, cha
     printf("_timezone = %d\n", _timezone);
     printf("_daylight = %d\n", _daylight);
     const long int tzdiff = -_timezone;
+    printf("tzdiff = %ld\n", tzdiff);
     const int h = abs(_timezone) / 3600 + _daylight;
+    printf("h = %d\n", h);
     const int m = (abs(_timezone) % 3600) / 60;
+    printf("m = %d\n", m);
     snprintf(tz, sizeof(tz), "%c%02d%02d", tzdiff < 0 ? '-' : '+', h, m);
+    printf("tz = %s\n", tz);
     strftime(time_fmt, sizeof(time_fmt), "%Y-%m-%dT%H:%M:%S.%%06u", t);
+    printf("time_fmt = %s\n", time_fmt);
     snprintf(str, size, time_fmt, ts->tv_usec);
+    printf("str (before) = %s\n", str);
     strlcat(str, tz, size); // append our timezone
+    printf("str (after) = %s\n", str);
 }
 #endif
 

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -200,6 +200,8 @@ static inline void WinStrftime(const struct timeval *ts, const struct tm *t, cha
 {
     char time_fmt[64] = { 0 };
     char tz[6] = { 0 };
+    printf("_timezone = %d\n", _timezone);
+    printf("_daylight = %d\n", _daylight);
     const long int tzdiff = -_timezone;
     const int h = abs(_timezone) / 3600 + _daylight;
     const int m = (abs(_timezone) % 3600) / 60;

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -210,7 +210,7 @@ static inline void WinStrftime(const struct timeval *ts, const struct tm *t, cha
     if (tzdiff < 0) {
         h = abs(_timezone) / 3600 - _daylight;
     } else {
-        h = abs(_timezone) / 3600 + _daylight;
+        h = abs(_timezone) / 3600;
     }
     printf("h = %d\n", h);
     const int m = (abs(_timezone) % 3600) / 60;

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -204,7 +204,7 @@ static inline void WinStrftime(const struct timeval *ts, const struct tm *t, cha
     printf("_daylight = %d\n", _daylight);
     const long int tzdiff = -_timezone;
     printf("tzdiff = %ld\n", tzdiff);
-    const int h = abs(_timezone) / 3600 + _daylight;
+    const int h = abs(_timezone) / 3600 - _daylight;
     printf("h = %d\n", h);
     const int m = (abs(_timezone) % 3600) / 60;
     printf("m = %d\n", m);

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -204,8 +204,8 @@ static inline void WinStrftime(const struct timeval *ts, const struct tm *t, cha
     char tz[6] = { 0 };
     printf("_timezone = %d\n", _timezone);
     printf("_daylight = %d\n", _daylight);
+    printf("_dstbias = %d\n", _dstbias);
     const long int tzdiff = -_timezone;
-    printf("tzdiff = %ld\n", tzdiff);
     printf("tzdiff = %ld\n", tzdiff);
     if (tzdiff < 0) {
         h = abs(_timezone) / 3600 - _daylight;

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -204,7 +204,7 @@ static inline void WinStrftime(const struct timeval *ts, const struct tm *t, cha
     printf("_daylight = %d\n", _daylight);
     const long int tzdiff = -_timezone;
     printf("tzdiff = %ld\n", tzdiff);
-    const int h = abs(_timezone) / 3600 - _daylight;
+    const int h = abs(_timezone) / 3600 + tzdiff < 0 ? -_daylight : _daylight;
     printf("h = %d\n", h);
     const int m = (abs(_timezone) % 3600) / 60;
     printf("m = %d\n", m);

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -204,7 +204,7 @@ static inline void WinStrftime(const struct timeval *ts, const struct tm *t, cha
     printf("_daylight = %d\n", _daylight);
     const long int tzdiff = -_timezone;
     printf("tzdiff = %ld\n", tzdiff);
-    const int h = abs(_timezone) / 3600 + tzdiff < 0 ? -_daylight : _daylight;
+    const int h = abs(_timezone) / 3600 + (tzdiff < 0 ? -_daylight : _daylight);
     printf("h = %d\n", h);
     const int m = (abs(_timezone) % 3600) / 60;
     printf("m = %d\n", m);

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -204,7 +204,7 @@ static inline void WinStrftime(const struct timeval *ts, const struct tm *t, cha
     printf("_daylight = %d\n", _daylight);
     const long int tzdiff = -_timezone;
     printf("tzdiff = %ld\n", tzdiff);
-    const int h = abs(_timezone) / 3600 + (tzdiff < 0 ? -_daylight : _daylight);
+    const int h = abs(_timezone) / 3600 - _daylight;
     printf("h = %d\n", h);
     const int m = (abs(_timezone) % 3600) / 60;
     printf("m = %d\n", m);

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -198,13 +198,20 @@ void TimeSetIncrementTime(uint32_t tv_sec)
  */
 static inline void WinStrftime(const struct timeval *ts, const struct tm *t, char *str, size_t size)
 {
+    int h;
+
     char time_fmt[64] = { 0 };
     char tz[6] = { 0 };
     printf("_timezone = %d\n", _timezone);
     printf("_daylight = %d\n", _daylight);
     const long int tzdiff = -_timezone;
     printf("tzdiff = %ld\n", tzdiff);
-    const int h = abs(_timezone) / 3600 - _daylight;
+    printf("tzdiff = %ld\n", tzdiff);
+    if (tzdiff < 0) {
+        h = abs(_timezone) / 3600 - _daylight;
+    } else {
+        h = abs(_timezone) / 3600 + _daylight;
+    }
     printf("h = %d\n", h);
     const int m = (abs(_timezone) % 3600) / 60;
     printf("m = %d\n", m);


### PR DESCRIPTION
I've got good news and bad news.

The good news is that I _think_ I stumbled onto the right math that corrects this. Using the wrccdc pcap and the branch for this PR at commit `da92b58` (which is in artifact `suricata-v5.0.3-brimphilrz7.windows-amd64.zip` on our storage bucket), I've tested out the change in this branch when setting my Windows system timezone to each of:

- Default UTC
- Pacific
- Amsterdam
- Tripoli
- Helsinki
- Arizona
- Chennai

This crosses a spectrum of timezones that are +/- UTC, do and don't observe daylight savings time, and in the case of Chennai is 30 minutes askew from how almost everyone else aligns time. In each case I was able to take the first ISO timestamp that ends up in the EVE JSON log, paste it into the "ISO 8601" box at https://www.timestamp-converter.com/, and in each case the "ISO 8601" output that it shows is the same `2018-03-23T19:58:22.825Z` that matches the UTC times Wireshark shows for the underlying timestamp.

The bad news is that I can't really explain why. 😄   I mean, if I stare at the inputs, I can see how it calculates the outputs. But I didn't fully understand the approach they were taking the first place. Maybe another pair of eyes can explain it.

Here's the output from all the runs.

---
### Default UTC
_timezone = 0
_daylight = 0
tzdiff = 0
tzdiff = 0
h = 0
m = 0
tz = +0000
time_fmt = 2018-03-23T19:58:22.%06u
str (before) = 2018-03-23T19:58:22.825466
str (after) = 2018-03-23T19:58:22.825466+0000
https://www.timestamp-converter.com/ says: 2018-03-23T19:58:22.825Z

### Pacific
_timezone = 28800
_daylight = 1
tzdiff = -28800
tzdiff = -28800
h = 7
m = 0
tz = -0700
time_fmt = 2018-03-23T12:58:22.%06u
str (before) = 2018-03-23T12:58:22.825466
str (after) = 2018-03-23T12:58:22.825466-0700
https://www.timestamp-converter.com/ says: 2018-03-23T19:58:22.825Z

### Amsterdam
_timezone = -3600
_daylight = 1
tzdiff = 3600
tzdiff = 3600
h = 1
m = 0
tz = +0100
time_fmt = 2018-03-23T20:58:22.%06u
str (before) = 2018-03-23T20:58:22.825466
str (after) = 2018-03-23T20:58:22.825466+0100
https://www.timestamp-converter.com/ says: 2018-03-23T19:58:22.825Z

### Tripoli
_timezone = -7200
_daylight = 0
tzdiff = 7200
tzdiff = 7200
h = 2
m = 0
tz = +0200
time_fmt = 2018-03-23T21:58:22.%06u
str (before) = 2018-03-23T21:58:22.825466
str (after) = 2018-03-23T21:58:22.825466+0200
https://www.timestamp-converter.com/ says: 2018-03-23T19:58:22.825Z

### Helsinki
_timezone = -7200
_daylight = 1
tzdiff = 7200
tzdiff = 7200
h = 2
m = 0
tz = +0200
time_fmt = 2018-03-23T21:58:22.%06u
str (before) = 2018-03-23T21:58:22.825466
str (after) = 2018-03-23T21:58:22.825466+0200
https://www.timestamp-converter.com/ says: 2018-03-23T19:58:22.825Z

### Arizona
_timezone = 25200
_daylight = 0
tzdiff = -25200
tzdiff = -25200
h = 7
m = 0
tz = -0700
time_fmt = 2018-03-23T12:58:22.%06u
str (before) = 2018-03-23T12:58:22.825466
str (after) = 2018-03-23T12:58:22.825466-0700
https://www.timestamp-converter.com/ says: 2018-03-23T19:58:22.825Z

### Chennai
_timezone = -19800
_daylight = 0
tzdiff = 19800
tzdiff = 19800
h = 5
m = 30
tz = +0530
time_fmt = 2018-03-24T01:28:22.%06u
str (before) = 2018-03-24T01:28:22.825466
str (after) = 2018-03-24T01:28:22.825466+0530
https://www.timestamp-converter.com/ says: 2018-03-23T19:58:22.825Z