### PR TITLE
Use UTC timestamps on Windows

### DIFF
--- a/src/util-time.h
+++ b/src/util-time.h
@@ -48,6 +48,7 @@ struct tm *SCLocalTime(time_t timep, struct tm *result);
 void CreateTimeString(const struct timeval *ts, char *str, size_t size);
 void CreateIsoTimeString(const struct timeval *ts, char *str, size_t size);
 void CreateUtcIsoTimeString(const struct timeval *ts, char *str, size_t size);
+void CreateUtcIsoTimeStringBrim(const struct timeval *ts, char *str, size_t size);
 void CreateFormattedTimeString(const struct tm *t, const char * fmt, char *str, size_t size);
 time_t SCMkTimeUtc(struct tm *tp);
 int SCStringPatternToTime(char *string, const char **patterns,


### PR DESCRIPTION
As a workaround for https://github.com/brimsec/build-suricata/issues/44, use UTC timestamps on Windows rather than try to jump through hoops to represent them in the local timezone. 

Since these logs are destined for Brim and end up as zng, the local timezone doesn't matter anyway.