### PR TITLE
Fix Rust library filename on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -293,7 +293,7 @@
             LDFLAGS="${LDFLAGS} -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid"
             WINDOWS_PATH="yes"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
-            #RUST_SURICATA_LIBNAME="suricata.lib"
+            RUST_SURICATA_LIBNAME="suricata.lib"
             RUST_LDADD="-luserenv -lshell32 -ladvapi32 -lgcc_eh"
             ;;
         *-*-cygwin)

--- a/configure.ac
+++ b/configure.ac
@@ -290,11 +290,10 @@
             ;;
         *-*-mingw32*|*-*-msys)
             CFLAGS="${CFLAGS} -DOS_WIN32"
-            LDFLAGS="${LDFLAGS} -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid"
             WINDOWS_PATH="yes"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
             RUST_SURICATA_LIBNAME="suricata.lib"
-            RUST_LDADD="-luserenv -lshell32 -ladvapi32 -lgcc_eh"
+            RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh"
             ;;
         *-*-cygwin)
             LUA_LIB_NAME="lua"

--- a/configure.ac
+++ b/configure.ac
@@ -293,7 +293,7 @@
             LDFLAGS="${LDFLAGS} -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid"
             WINDOWS_PATH="yes"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
-            RUST_SURICATA_LIBNAME="suricata.lib"
+            #RUST_SURICATA_LIBNAME="suricata.lib"
             RUST_LDADD="-luserenv -lshell32 -ladvapi32 -lgcc_eh"
             ;;
         *-*-cygwin)

--- a/configure.ac
+++ b/configure.ac
@@ -292,7 +292,6 @@
             CFLAGS="${CFLAGS} -DOS_WIN32"
             WINDOWS_PATH="yes"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
-            RUST_SURICATA_LIBNAME="suricata.lib"
             RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh"
             ;;
         *-*-cygwin)
@@ -2405,10 +2404,11 @@ fi
     fi
 
     if test "x$enable_debug" = "xyes"; then
-      RUST_SURICATA_LIB="../rust/target/${RUST_SURICATA_LIB_XC_DIR}debug/${RUST_SURICATA_LIBNAME}"
+      RUST_SURICATA_LIBDIR="../rust/target/${RUST_SURICATA_LIB_XC_DIR}debug"
     else
-      RUST_SURICATA_LIB="../rust/target/${RUST_SURICATA_LIB_XC_DIR}release/${RUST_SURICATA_LIBNAME}"
+      RUST_SURICATA_LIBDIR="../rust/target/${RUST_SURICATA_LIB_XC_DIR}release"
     fi
+    RUST_SURICATA_LIB="${RUST_SURICATA_LIBDIR}/${RUST_SURICATA_LIBNAME}"
 
     RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
     CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen/c-headers"
@@ -2591,6 +2591,8 @@ AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(CONFIGURE_DATAROOTDIR)
 AC_SUBST(PACKAGE_VERSION)
+AC_SUBST(RUST_FEATURES)
+AC_SUBST(RUST_SURICATA_LIBDIR)
 
 AC_CONFIG_FILES(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config)
 AC_CONFIG_FILES(qa/Makefile qa/coccinelle/Makefile)

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -39,6 +39,10 @@ else
 		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 endif
+	if test -e $(RUST_SURICATA_LIBDIR)/suricata.lib; then \
+		cp $(RUST_SURICATA_LIBDIR)/suricata.lib \
+			$(RUST_SURICATA_LIBDIR)/libsuricata.a; \
+	fi
 
 clean-local:
 	-rm -rf target gen


### PR DESCRIPTION
Our Suricata build on Windows suffered some bit rot, as shown in this Action failure:

https://github.com/brimsec/build-suricata/runs/1704451655?check_suite_focus=true#step:8:1418

In `diff`'ing what changed since the last successful Windows build, one thing that stood out is that the Rust version grabbed via `pacman -Su mingw-w64-x86_64-rust` jumped from 1.43.0 to 1.48.0. Sure enough, the [releases notes for 1.44.0](https://github.com/rust-lang/rust/releases/tag/1.44.0) describes a change as "[Rustc now correctly generates static libraries on Windows GNU targets with the .a extension, rather than the previous .lib](https://github.com/rust-lang/rust/pull/70937/)" That led me to find https://github.com/OISF/suricata/pull/5623 where the Suricata maintainers adapted to that change. I cherry-picked the two commits from that PR into this branch and made a companion [build-suricata/fix-build-windows-lib](https://github.com/brimsec/build-suricata/tree/fix-build-windows-lib) branch that points to it, and you can see the successful build in this Actions run:

https://github.com/brimsec/build-suricata/runs/1705758315?check_suite_focus=true