### PR TITLE
Cherry pick Suricata fix tinyurl.com/mpsr6r3j

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -292,7 +292,7 @@
             CFLAGS="${CFLAGS} -DOS_WIN32"
             WINDOWS_PATH="yes"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
-            RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh"
+            RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh -lbcrypt"
             ;;
         *-*-cygwin)
             LUA_LIB_NAME="lua"


### PR DESCRIPTION
This part of the fixes needed for https://github.com/brimdata/build-suricata/pull/64 belongs on the Suricata side of things. In this case I thankfully was able to find where the Suricata devs had already made the same fix themselves at https://github.com/OISF/suricata/commit/e93dc24383443398d6a2e888931d7000b392c09a.